### PR TITLE
 Fix for warning: clojure.lang.Repl is deprecated.

### DIFF
--- a/clj
+++ b/clj
@@ -19,7 +19,7 @@ fi
 
 if [ -z "$1" ]; then 
 	$JAVA -server -cp $CP \
-	    jline.ConsoleRunner clojure.lang.Repl    
+	    jline.ConsoleRunner clojure.main
 else
 	scriptname=$1
 	$JAVA -server -cp $CP clojure.lang.Script $scriptname -- $*


### PR DESCRIPTION
Today when I have installed your script clj it generates me a warning:

$ clj
WARNING: clojure.lang.Repl is deprecated.
Instead, use clojure.main like this:
java -cp clojure.jar clojure.main -i init.clj -r args...
Clojure 1.2.0

So I have fixed it and it's in this pull request. It works for me and my version 1.2 on Mac OS X.

Thanks,
Rafal.
